### PR TITLE
prevent error when properNoun is null / undefined

### DIFF
--- a/possessive.js
+++ b/possessive.js
@@ -2,6 +2,9 @@
 angular.module('filter.possessive', [])
     .filter('possessive', function () {
         return function (properNoun) {
+            if (properNoun == null) {
+                return properNoun;
+            }
             if (properNoun.charAt(properNoun.length-1) == "s" || properNoun.charAt(properNoun.length-1) == "S") {
                 return properNoun + "'";
             }


### PR DESCRIPTION
e.g. before Angular has bound a variable
